### PR TITLE
fix: update SHA256 checksum and docs for NixOS installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Install it using cargo!
 ```bash
 cargo install simple-commit
 ```
+Nixos
+
+```bash
+nix profile install github:romancitodev/simple-commits
+```
 
 ## 🛠 Configuration
 

--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ let
   # fenix: rustup replacement for reproducible builds
   toolchain = fenix.${system}.fromToolchainFile {
     file = ./rust-toolchain.toml;
-    sha256 = "sha256-Ngiz76YP4HTY75GGdH2P+APE/DEIx2R/Dn+BwwOyzZU=";
+    sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
   };
   # crane: cargo and artifacts manager
   craneLib = crane.${system}.overrideToolchain toolchain;


### PR DESCRIPTION
**SHA256 Checksum Update:** Fixes the incorrect SHA256 checksum for the `rust-toolchain.toml` file.
 -  The previous checksum was causing a hash mismatch error during the build process. Correcting it ensures the integrity of the `rust-toolchain.toml` file.

**Documentation Update:** Adds installation instructions for the `simple-commits` profile on NixOS to the `README.md`.
  -  Including the installation instructions helps users easily set up the `simple-commits` profile on NixOS, improving the documentation and usability.