### PR TITLE
fix: Refactor apps configuration to explicitly define program path and type

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -57,8 +57,11 @@ in
 {
   # `nix run`
   apps = rec {
-    simpleCommits = simpleCommitsPkg.app;
-    default = simpleCommits;
+    simpleCommits = simpleCommitsPkg.pkg;
+    default = {
+      program = "${simpleCommits}/bin/sc";
+      type = "app";
+      };
   };
   # `nix build`
   packages = rec {


### PR DESCRIPTION
Issue solved: the application was not running correctly with `nix run`.