### PR TITLE
fix: simplify Rust toolchain setup to avoid manual hash updates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,10 +24,7 @@ in
 }:
 let
   # fenix: rustup replacement for reproducible builds
-  toolchain = fenix.${system}.fromToolchainFile {
-    file = ./rust-toolchain.toml;
-    sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
-  };
+  toolchain = fenix.${system}.stable.minimalToolchain;
   # crane: cargo and artifacts manager
   craneLib = crane.${system}.overrideToolchain toolchain;
   # cranix: extends crane building system with workspace bin building and Mold + Cranelift integrations


### PR DESCRIPTION
Previously, every time we updated `rustc` or `cargo`, we had to manually update the sha256 hash for the rust-toolchain.toml file. This process was tedious and prone to errors.

By switching to `fenix.${system}.minimal.toolchain`, we eliminate the need to manage the hash manually. This configuration simplifies updates and reduces the likelihood of errors.